### PR TITLE
redirect to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # domokit.github.io
+
+View the [documentation for Sky](http://domokit.github.io/docs/sky/).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>domokit.github.io</title>
+    <META http-equiv="refresh" content="0;URL=http://domokit.github.io/docs/sky/">
+  </head>
+  <body>
+    <p>The documentation for Sky is available at http://domokit.github.io/docs/sky/.</p>
+  </body>
+</html>


### PR DESCRIPTION
Add a redirect to http://domokit.github.io/docs/sky/ so that the http://domokit.github.io/ site doesn't return a 404 :)

fix https://github.com/domokit/domokit.github.io/issues/1
